### PR TITLE
Feat/simplify passwords handling

### DIFF
--- a/modules/argo_cd_config/main.tf
+++ b/modules/argo_cd_config/main.tf
@@ -23,37 +23,6 @@ resource "kubernetes_secret" "argocd_secret" {
   }
 }
 
-/*
-TODO: CHECK IF WAIT IS STILL NEEDED
-resource "null_resource" "wait_for_argocd_server" {
-  provisioner "local-exec" {
-    quiet   = true
-    command = <<EOT
-      set -e
-      export KUBECONFIG
-      kubectl config use-context ${var.kubeconfig_context}
-      for i in {1..30}; do
-        READY=$(kubectl get pods -n ${var.argocd_namespace} -l app.kubernetes.io/name=argocd-server -o jsonpath="{.items[0].status.containerStatuses[0].ready}")
-        if [ "$READY" = "true" ]; then
-          exit 0
-        else
-          echo "Waiting for ArgoCD gRPC API... ($i)"
-          sleep 10
-        fi
-      done
-      echo "Timed out waiting for ArgoCD gRPC API" >&2
-      exit 1
-    EOT
-    environment = {
-      KUBECONFIG = pathexpand(var.kubeconfig_path)
-    }
-  }
-  triggers = {
-    always_run = timestamp()
-  }
-}
-*/
-
 # AppProject and ApplicationSet
 
 resource "helm_release" "argo_deploy" {
@@ -65,6 +34,4 @@ resource "helm_release" "argo_deploy" {
   create_namespace = false
   wait             = true
   values           = [var.argo_deploy_helm_values]
-
-  depends_on = [null_resource.wait_for_argocd_server]
 }

--- a/modules/argo_cd_config/main.tf
+++ b/modules/argo_cd_config/main.tf
@@ -1,9 +1,10 @@
-# Read values
 locals {
   argocd_values_parsed = yamldecode(var.argocd_helm_values)
   argocd_oidc_config   = yamldecode(local.argocd_values_parsed.argo-cd.configs.cm["oidc.config"])
   argocd_oidc_secret   = regex("\\$(.*?):", local.argocd_oidc_config.clientSecret).0
 }
+
+# Secrets
 
 resource "kubernetes_secret" "argocd_secret" {
   metadata {
@@ -22,6 +23,8 @@ resource "kubernetes_secret" "argocd_secret" {
   }
 }
 
+/*
+TODO: CHECK IF WAIT IS STILL NEEDED
 resource "null_resource" "wait_for_argocd_server" {
   provisioner "local-exec" {
     quiet   = true
@@ -49,6 +52,9 @@ resource "null_resource" "wait_for_argocd_server" {
     always_run = timestamp()
   }
 }
+*/
+
+# AppProject and ApplicationSet
 
 resource "helm_release" "argo_deploy" {
   name             = "${var.cluster_name}-${var.argo_deploy_chart_name}"

--- a/modules/argo_cd_config/variables.tf
+++ b/modules/argo_cd_config/variables.tf
@@ -43,16 +43,6 @@ variable "harbor_domain" {
   type        = string
 }
 
-variable "kubeconfig_path" {
-  description = "Path to the Kubernetes config file"
-  type        = string
-}
-
-variable "kubeconfig_context" {
-  description = "Kubernetes context to use"
-  type        = string
-}
-
 variable "helm_registry" {
   description = "Helm chart registry to get the chart from"
   type        = string

--- a/modules/certificate_authorities/main.tf
+++ b/modules/certificate_authorities/main.tf
@@ -67,6 +67,10 @@ resource "null_resource" "wait_for_cert_manager_webhook" {
     }
   }
 
+  triggers = {
+    always_run = timestamp()
+  }
+
   depends_on = [helm_release.cert_manager]
 }
 

--- a/modules/certificate_authorities/main.tf
+++ b/modules/certificate_authorities/main.tf
@@ -50,7 +50,7 @@ resource "helm_release" "cert_manager" {
 
 resource "null_resource" "wait_for_cert_manager_webhook" {
   provisioner "local-exec" {
-    quiet = true
+    quiet   = true
     command = <<EOT
       set -e
       export KUBECONFIG
@@ -87,5 +87,5 @@ resource "helm_release" "selfsigned" {
 
   values = [var.selfsigned_helm_values]
 
-  depends_on = [ null_resource.wait_for_cert_manager_webhook ]
+  depends_on = [null_resource.wait_for_cert_manager_webhook]
 }

--- a/modules/certificate_authorities/variables.tf
+++ b/modules/certificate_authorities/variables.tf
@@ -47,3 +47,13 @@ variable "selfsigned_helm_values" {
   description = "Self-Signed Issuer Helm chart values"
   type        = string
 }
+
+variable "kubeconfig_path" {
+  description = "Path to the Kubernetes config file"
+  type        = string
+}
+
+variable "kubeconfig_context" {
+  description = "Kubernetes context to use"
+  type        = string
+}

--- a/modules/harbor_config/main.tf
+++ b/modules/harbor_config/main.tf
@@ -17,9 +17,6 @@ resource "harbor_project" "projects" {
 resource "random_password" "argocd_robot_password" {
   length      = 12
   special     = false
-  upper       = true
-  lower       = true
-  numeric     = true
   min_upper   = 1
   min_lower   = 1
   min_numeric = 1
@@ -111,9 +108,6 @@ resource "harbor_robot_account" "argocd" {
 resource "random_password" "argoci_robot_password" {
   length      = 12
   special     = false
-  upper       = true
-  lower       = true
-  numeric     = true
   min_upper   = 1
   min_lower   = 1
   min_numeric = 1
@@ -623,9 +617,11 @@ resource "null_resource" "pull_charts" {
     EOT
   }
   for_each = var.charts_versions
+
   triggers = {
     always_run = timestamp()
   }
+
   depends_on = [harbor_project.projects]
 }
 
@@ -647,9 +643,11 @@ resource "null_resource" "push_charts" {
     EOT
   }
   for_each = var.charts_versions
+
   triggers = {
     always_run = timestamp()
   }
+
   depends_on = [
     harbor_project.projects,
     null_resource.pull_charts

--- a/modules/ingress_nginx/main.tf
+++ b/modules/ingress_nginx/main.tf
@@ -1,11 +1,13 @@
-# Namespace Definitions
+# Namespace
+
 resource "kubernetes_namespace" "ingress_nginx" {
   metadata {
     name = var.namespace
   }
 }
 
-# Ingress-Nginx Deployment
+# Ingress-Nginx
+
 resource "helm_release" "ingress_nginx" {
   name             = "${var.cluster_name}-${var.chart_name}"
   repository       = "oci://${var.helm_registry}"
@@ -19,13 +21,9 @@ resource "helm_release" "ingress_nginx" {
   depends_on = [kubernetes_namespace.ingress_nginx]
 }
 
+# Load Balancer
+
 resource "null_resource" "wait_for_lb_ip" {
-  depends_on = [helm_release.ingress_nginx]
-
-  triggers = {
-    always_run = timestamp()
-  }
-
   provisioner "local-exec" {
     quiet   = true
     command = <<EOT
@@ -47,6 +45,12 @@ resource "null_resource" "wait_for_lb_ip" {
       KUBECONFIG = pathexpand(var.kubeconfig_path)
     }
   }
+
+  triggers = {
+    always_run = timestamp()
+  }
+
+  depends_on = [helm_release.ingress_nginx]
 }
 
 data "kubernetes_service" "loadbalancer" {

--- a/modules/keycloak_config/main.tf
+++ b/modules/keycloak_config/main.tf
@@ -16,9 +16,7 @@ resource "keycloak_group_roles" "chorus_admins_group_roles" {
   realm_id = data.keycloak_realm.master.id
   group_id = keycloak_group.chorus_admin.id
 
-  role_ids = [
-    data.keycloak_role.admin.id
-  ]
+  role_ids = [data.keycloak_role.admin.id]
 }
 
 resource "keycloak_realm" "infra" {

--- a/stage_01/main.tf
+++ b/stage_01/main.tf
@@ -64,6 +64,9 @@ module "certificate_authorities" {
   selfsigned_chart_name    = var.selfsigned_chart_name
   selfsigned_chart_version = local.selfsigned_chart_version
   selfsigned_helm_values   = file("${var.helm_values_path}/${var.cluster_name}/${var.selfsigned_chart_name}/values.yaml")
+
+  kubeconfig_path    = var.kubeconfig_path
+  kubeconfig_context = var.kubeconfig_context
 }
 
 module "keycloak" {

--- a/stage_02/main.tf
+++ b/stage_02/main.tf
@@ -406,8 +406,6 @@ module "argocd_config" {
   source = "../modules/argo_cd_config"
 
   cluster_name       = var.cluster_name
-  kubeconfig_path    = var.kubeconfig_path
-  kubeconfig_context = var.kubeconfig_context
 
   argocd_helm_values = file("${var.helm_values_path}/${var.cluster_name}/${var.argocd_chart_name}/values.yaml")
   argocd_namespace   = jsondecode(file("${var.helm_values_path}/${var.cluster_name}/${var.argocd_chart_name}/config.json")).namespace

--- a/stage_02/main.tf
+++ b/stage_02/main.tf
@@ -405,7 +405,7 @@ resource "null_resource" "wait_for_argocd" {
 module "argocd_config" {
   source = "../modules/argo_cd_config"
 
-  cluster_name       = var.cluster_name
+  cluster_name = var.cluster_name
 
   argocd_helm_values = file("${var.helm_values_path}/${var.cluster_name}/${var.argocd_chart_name}/values.yaml")
   argocd_namespace   = jsondecode(file("${var.helm_values_path}/${var.cluster_name}/${var.argocd_chart_name}/config.json")).namespace


### PR DESCRIPTION
Simplifying secret creation because
- Terraform will fail to create a secret "my-secret" if "my-secret" already exists without being found in terraform state (i.e. not managed by terraform)
- if a random password has already been created in a previous terraform plan/apply cycle, terraform will not regenerate it

Also
- cleaned up
- fixed the cert-manager webhook wait block
- removed the argocd server wait block (now obselete because we are deploying appproject and applicationset through the argo-deploy helm chart)