### PR TITLE
Feat/use remote state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,13 +8,14 @@ export TF_VAR_helm_registry_password="password"
 export TF_VAR_cluster_name="chorus-build"
 export TF_VAR_helm_registry="your-favorite-registry"
 
+export TF_VAR_github_username="John_Doe"
 # The following GitHub PATs need
 # Read access to actions, metadata, and repository hooks
 # Read and Write access to code, commit statuses, and pull requests
-export TF_VAR_argoci_github_workbench_operator_token="github_pat_"
-export TF_VAR_argoci_github_chorus_web_ui_token="github_pat_"
-export TF_VAR_argoci_github_images_token="github_pat_"
-export TF_VAR_argoci_github_chorus_backend_token="github_pat_"
+export TF_VAR_github_workbench_operator_token="github_pat_"
+export TF_VAR_github_chorus_web_ui_token="github_pat_"
+export TF_VAR_github_images_token="github_pat_"
+export TF_VAR_github_chorus_backend_token="github_pat_"
 
 # Optional variables
 # export TF_VAR_github_orga="CHORUS-TRE"

--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ export TF_VAR_argoci_github_chorus_backend_token="github_pat_"
 # export TF_VAR_helm_values_path="../values"
 # The following GitHub PAT is only needed 
 # for application manifests located in private repository,
-# in which case itt needs
+# in which case it needs
 # Read access to code and metadata
 # export TF_VAR_helm_values_pat=null
 

--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,17 @@ export TF_VAR_kubeconfig_context="chorus-build"
 
 export TF_VAR_helm_registry_username="John_Doe"
 export TF_VAR_helm_registry_password="password"
-export TF_VAR_helm_values_pat="github_pat_"
 
 export TF_VAR_cluster_name="chorus-build"
 export TF_VAR_helm_registry="your-favorite-registry"
+
+# The following GitHub PATs need
+# Read access to actions, metadata, and repository hooks
+# Read and Write access to code, commit statuses, and pull requests
+export TF_VAR_argoci_github_workbench_operator_token="github_pat_"
+export TF_VAR_argoci_github_chorus_web_ui_token="github_pat_"
+export TF_VAR_argoci_github_images_token="github_pat_"
+export TF_VAR_argoci_github_chorus_backend_token="github_pat_"
 
 # Optional variables
 # export TF_VAR_github_orga="CHORUS-TRE"
@@ -16,6 +23,11 @@ export TF_VAR_helm_registry="your-favorite-registry"
 
 # export TF_VAR_helm_values_credentials_secret="argo-cd-github-environments"
 # export TF_VAR_helm_values_path="../values"
+# The following GitHub PAT is only needed 
+# for application manifests located in private repository,
+# in which case itt needs
+# Read access to code and metadata
+# export TF_VAR_helm_values_pat=null
 
 # export TF_VAR_ingress_nginx_chart_name="ingress-nginx"
 # export TF_VAR_cert_manager_chart_name="cert-manager"
@@ -30,7 +42,6 @@ export TF_VAR_helm_registry="your-favorite-registry"
 # export TF_VAR_keycloak_oidc_admin_group="HarborAdmins"
 # export TF_VAR_harbor_admin_username="admin"
 # export TF_VAR_harbor_keycloak_base_url="/harbor/projects"
-
 
 # export TF_VAR_argocd_harbor_robot_username="argo-cd"
 # export TF_VAR_argoci_harbor_robot_username="argo-ci"

--- a/modules/argo_cd/main.tf
+++ b/modules/argo_cd/main.tf
@@ -35,7 +35,26 @@ resource "kubernetes_secret" "argocd_cache" {
   depends_on = [kubernetes_namespace.argocd]
 }
 
-resource "kubernetes_secret" "environments_repository_credentials" {
+resource "kubernetes_secret" "public_environments_repository_credentials" {
+  metadata {
+    name      = var.helm_charts_values_credentials_secret
+    namespace = var.argocd_namespace
+    labels = {
+      "argocd.argoproj.io/secret-type" = "repository"
+    }
+  }
+
+  data = {
+    url  = var.helm_values_url
+    type = "git"
+  }
+
+  depends_on = [kubernetes_namespace.argocd]
+
+  count = coalesce(var.helm_values_pat, "public") == "public" ? 1 : 0
+}
+
+resource "kubernetes_secret" "private_environments_repository_credentials" {
   metadata {
     name      = var.helm_charts_values_credentials_secret
     namespace = var.argocd_namespace
@@ -51,6 +70,8 @@ resource "kubernetes_secret" "environments_repository_credentials" {
   }
 
   depends_on = [kubernetes_namespace.argocd]
+
+  count = coalesce(var.helm_values_pat, "public") == "public" ? 0 : 1
 }
 
 # The following secret name is hardcoded 

--- a/modules/argo_ci_config/README.md
+++ b/modules/argo_ci_config/README.md
@@ -1,0 +1,21 @@
+# argo_ci_config Terraform Module
+
+This module provisions Kubernetes secrets used by Argo CI. These secrets are designed to securely store credentials for various GitHub repositories that Argo CI interacts with, such as for Workbench Operator, Chorus Web UI, Images, and Chorus Backend.
+
+## Features
+
+- Creates Kubernetes `Secret` resources for GitHub Personal Access Tokens (PATs).
+- Securely stores sensitive GitHub tokens in the specified namespace.
+- Supports token management for multiple GitHub repositories used by Argo CI workflows.
+
+## Prerequisites
+
+- An existing Kubernetes cluster.
+- Kubernetes provider configured in Terraform.
+- Sufficient permissions to create `Secret` resources in the target namespace.
+- The ArgoCD namespace (where these secrets will reside) must exist.
+
+## References
+
+- [Terraform Kubernetes Provider](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs)
+- [GitHub Personal Access Tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)

--- a/modules/argo_ci_config/main.tf
+++ b/modules/argo_ci_config/main.tf
@@ -1,3 +1,8 @@
+locals {
+  argoci_values_parsed         = yamldecode(var.argoci_helm_values)
+  argoci_sensor_regcred_secret = yamldecode(local.argoci_values_parsed.sensor.dockerConfig.secretName)
+}
+
 resource "random_password" "argoci_github_workbench_operator_secret" {
   length  = 32
   special = false
@@ -65,3 +70,32 @@ resource "kubernetes_secret" "argoci_github_chorus_backend" {
     token  = var.argoci_github_chorus_backend_token
   }
 }
+
+resource "kubernetes_secret" "argoci_github_chorus_backend" {
+  metadata {
+    name      = local.argoci_sensor_regcred_secret
+    namespace = var.argoci_namespace
+  }
+
+  data = {
+    ".dockerconfigjson" = jsonencode({
+      "auths" : {
+        "${var.registry_server}" = {
+          "auth" : base64encode("${var.registry_username}:${var.registry_password}")
+        }
+      }
+    })
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
+}
+
+# TODO:
+# chorus-backend: argo-workflows-github-chorus-backend
+#  chorus-web-ui: argo-workflows-github-chorus-web-ui
+#  workbench-operator: argo-workflows-github-workbench-operator
+# https://github.com/CHORUS-TRE/chorus-tre/blob/903120f86952cd18d8bd183b6a96a9f79f82033b/charts/argo-ci/values.yaml#L43C1-L46C63
+
+# secret has the two following fields
+# username
+# password

--- a/modules/argo_ci_config/main.tf
+++ b/modules/argo_ci_config/main.tf
@@ -1,7 +1,10 @@
 locals {
   argoci_values_parsed         = yamldecode(var.argoci_helm_values)
   argoci_sensor_regcred_secret = yamldecode(local.argoci_values_parsed.sensor.dockerConfig.secretName)
+  webhook_events               = { for event in local.argoci_values_parsed.webhookEvents : event.name => event.secretName }
 }
+
+# Workbench operator
 
 resource "random_password" "argoci_github_workbench_operator_secret" {
   length  = 32
@@ -10,15 +13,36 @@ resource "random_password" "argoci_github_workbench_operator_secret" {
 
 resource "kubernetes_secret" "argoci_github_workbench_operator" {
   metadata {
-    name      = "argo-ci-github-workbench-operator"
+    name      = local.webhook_events["workbench-operator"]
     namespace = var.argoci_namespace
   }
 
   data = {
     secret = random_password.argoci_github_workbench_operator_secret.result
-    token  = var.argoci_github_workbench_operator_token
+    token  = var.github_workbench_operator_token
+  }
+
+  lifecycle {
+    precondition {
+      condition     = anytrue([for k, v in local.webhook_events : k == "workbench-operator"])
+      error_message = "Not found: 'workbench-operator' webhook event missing in argo-ci Helm values"
+    }
   }
 }
+
+resource "kubernetes_secret" "argo_workflows_github_workbench_operator" {
+  metadata {
+    name      = "argo-workflows-github-workbench-operator"
+    namespace = var.argoci_namespace
+  }
+
+  data = {
+    username = var.github_username
+    password = var.github_workbench_operator_token
+  }
+}
+
+# CHORUS Web UI
 
 resource "random_password" "argoci_github_chorus_web_ui_secret" {
   length  = 32
@@ -27,15 +51,36 @@ resource "random_password" "argoci_github_chorus_web_ui_secret" {
 
 resource "kubernetes_secret" "argoci_github_chorus_web_ui" {
   metadata {
-    name      = "argo-ci-github-chorus-web-ui"
+    name      = local.webhook_events["chorus-web-ui"]
     namespace = var.argoci_namespace
   }
 
   data = {
     secret = random_password.argoci_github_chorus_web_ui_secret.result
-    token  = var.argoci_github_chorus_web_ui_token
+    token  = var.github_chorus_web_ui_token
+  }
+
+  lifecycle {
+    precondition {
+      condition     = anytrue([for k, v in local.webhook_events : k == "chorus-web-ui"])
+      error_message = "Not found: 'chorus-web-ui' webhook event missing in argo-ci Helm values"
+    }
   }
 }
+
+resource "kubernetes_secret" "argo_workflows_github_chorus_web_ui" {
+  metadata {
+    name      = "argo-workflows-github-chorus-web-ui"
+    namespace = var.argoci_namespace
+  }
+
+  data = {
+    username = var.github_username
+    password = var.github_chorus_web_ui_token
+  }
+}
+
+# Images
 
 resource "random_password" "argoci_github_images_secret" {
   length  = 32
@@ -44,15 +89,24 @@ resource "random_password" "argoci_github_images_secret" {
 
 resource "kubernetes_secret" "argoci_github_images" {
   metadata {
-    name      = "argo-ci-github-images"
+    name      = local.webhook_events["ci"]
     namespace = var.argoci_namespace
   }
 
   data = {
     secret = random_password.argoci_github_images_secret.result
-    token  = var.argoci_github_images_token
+    token  = var.github_images_token
+  }
+
+  lifecycle {
+    precondition {
+      condition     = anytrue([for k, v in local.webhook_events : k == "ci"])
+      error_message = "Not found: 'ci' webhook event missing in argo-ci Helm values"
+    }
   }
 }
+
+# CHORUS Backend
 
 resource "random_password" "argoci_github_chorus_backend_secret" {
   length  = 32
@@ -61,17 +115,38 @@ resource "random_password" "argoci_github_chorus_backend_secret" {
 
 resource "kubernetes_secret" "argoci_github_chorus_backend" {
   metadata {
-    name      = "argo-ci-github-chorus-backend"
+    name      = local.webhook_events["chorus-backend"]
     namespace = var.argoci_namespace
   }
 
   data = {
     secret = random_password.argoci_github_chorus_backend_secret.result
-    token  = var.argoci_github_chorus_backend_token
+    token  = var.github_chorus_backend_token
+  }
+
+  lifecycle {
+    precondition {
+      condition     = anytrue([for k, v in local.webhook_events : k == "chorus-backend"])
+      error_message = "Not found: 'chorus-backend' webhook event missing in argo-ci Helm values"
+    }
   }
 }
 
-resource "kubernetes_secret" "argoci_github_chorus_backend" {
+resource "kubernetes_secret" "argo_workflows_github_chorus_backend" {
+  metadata {
+    name      = "argo-workflows-github-chorus-backend"
+    namespace = var.argoci_namespace
+  }
+
+  data = {
+    username = var.github_username
+    password = var.github_chorus_backend_token
+  }
+}
+
+# Sensor
+
+resource "kubernetes_secret" "argoci_sensor_regcred_secret" {
   metadata {
     name      = local.argoci_sensor_regcred_secret
     namespace = var.argoci_namespace
@@ -89,13 +164,3 @@ resource "kubernetes_secret" "argoci_github_chorus_backend" {
 
   type = "kubernetes.io/dockerconfigjson"
 }
-
-# TODO:
-# chorus-backend: argo-workflows-github-chorus-backend
-#  chorus-web-ui: argo-workflows-github-chorus-web-ui
-#  workbench-operator: argo-workflows-github-workbench-operator
-# https://github.com/CHORUS-TRE/chorus-tre/blob/903120f86952cd18d8bd183b6a96a9f79f82033b/charts/argo-ci/values.yaml#L43C1-L46C63
-
-# secret has the two following fields
-# username
-# password

--- a/modules/argo_ci_config/main.tf
+++ b/modules/argo_ci_config/main.tf
@@ -6,7 +6,7 @@ resource "random_password" "argoci_github_workbench_operator_secret" {
 resource "kubernetes_secret" "argoci_github_workbench_operator" {
   metadata {
     name      = "argo-ci-github-workbench-operator"
-    namespace = var.argocd_namespace
+    namespace = var.argoci_namespace
   }
 
   data = {
@@ -23,7 +23,7 @@ resource "random_password" "argoci_github_chorus_web_ui_secret" {
 resource "kubernetes_secret" "argoci_github_chorus_web_ui" {
   metadata {
     name      = "argo-ci-github-chorus-web-ui"
-    namespace = var.argocd_namespace
+    namespace = var.argoci_namespace
   }
 
   data = {
@@ -39,8 +39,8 @@ resource "random_password" "argoci_github_images_secret" {
 
 resource "kubernetes_secret" "argoci_github_images" {
   metadata {
-    name      = "argo-ci-github-images-secret"
-    namespace = var.argocd_namespace
+    name      = "argo-ci-github-images"
+    namespace = var.argoci_namespace
   }
 
   data = {
@@ -56,8 +56,8 @@ resource "random_password" "argoci_github_chorus_backend_secret" {
 
 resource "kubernetes_secret" "argoci_github_chorus_backend" {
   metadata {
-    name      = "argo-ci-github-chorus-backend-secret"
-    namespace = var.argocd_namespace
+    name      = "argo-ci-github-chorus-backend"
+    namespace = var.argoci_namespace
   }
 
   data = {

--- a/modules/argo_ci_config/main.tf
+++ b/modules/argo_ci_config/main.tf
@@ -1,0 +1,67 @@
+resource "random_password" "argoci_github_workbench_operator_secret" {
+  length  = 32
+  special = false
+}
+
+resource "kubernetes_secret" "argoci_github_workbench_operator" {
+  metadata {
+    name      = "argo-ci-github-workbench-operator"
+    namespace = var.argocd_namespace
+  }
+
+  data = {
+    secret = random_password.argoci_github_workbench_operator_secret.result
+    token  = var.argoci_github_workbench_operator_token
+  }
+}
+
+resource "random_password" "argoci_github_chorus_web_ui_secret" {
+  length  = 32
+  special = false
+}
+
+resource "kubernetes_secret" "argoci_github_chorus_web_ui" {
+  metadata {
+    name      = "argo-ci-github-chorus-web-ui"
+    namespace = var.argocd_namespace
+  }
+
+  data = {
+    secret = random_password.argoci_github_chorus_web_ui_secret.result
+    token  = var.argoci_github_chorus_web_ui_token
+  }
+}
+
+resource "random_password" "argoci_github_images_secret" {
+  length  = 32
+  special = false
+}
+
+resource "kubernetes_secret" "argoci_github_images" {
+  metadata {
+    name      = "argo-ci-github-images-secret"
+    namespace = var.argocd_namespace
+  }
+
+  data = {
+    secret = random_password.argoci_github_images_secret.result
+    token  = var.argoci_github_images_token
+  }
+}
+
+resource "random_password" "argoci_github_chorus_backend_secret" {
+  length  = 32
+  special = false
+}
+
+resource "kubernetes_secret" "argoci_github_chorus_backend" {
+  metadata {
+    name      = "argo-ci-github-images-secret"
+    namespace = var.argocd_namespace
+  }
+
+  data = {
+    secret = random_password.argoci_github_chorus_backend_secret.result
+    token  = var.argoci_github_chorus_backend_token
+  }
+}

--- a/modules/argo_ci_config/main.tf
+++ b/modules/argo_ci_config/main.tf
@@ -56,7 +56,7 @@ resource "random_password" "argoci_github_chorus_backend_secret" {
 
 resource "kubernetes_secret" "argoci_github_chorus_backend" {
   metadata {
-    name      = "argo-ci-github-images-secret"
+    name      = "argo-ci-github-chorus-backend-secret"
     namespace = var.argocd_namespace
   }
 

--- a/modules/argo_ci_config/provider.tf
+++ b/modules/argo_ci_config/provider.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.36.0"
+    }
+    random = {
+      source  = "registry.terraform.io/hashicorp/random"
+      version = "3.7.2"
+    }
+  }
+  # Provider functions require Terraform 1.8 and later.
+  required_version = ">= 1.8.0"
+}

--- a/modules/argo_ci_config/variables.tf
+++ b/modules/argo_ci_config/variables.tf
@@ -3,6 +3,11 @@ variable "argoci_namespace" {
   type        = string
 }
 
+variable "argoci_helm_values" {
+  description = "ArgoCI Helm chart values"
+  type        = string
+}
+
 variable "argoci_github_workbench_operator_token" {
   description = "GitHub token for the Workbench Operator repository"
   type        = string
@@ -23,6 +28,22 @@ variable "argoci_github_images_token" {
 
 variable "argoci_github_chorus_backend_token" {
   description = "GitHub token for the Chorus Backend repository"
+  type        = string
+  sensitive   = true
+}
+
+variable "registry_server" {
+  description = "The container registry server (e.g. Harbor)"
+  type        = string
+}
+
+variable "registry_username" {
+  description = "The robot username for the container registry"
+  type        = string
+}
+
+variable "registry_password" {
+  description = "The robot password for the container registry"
   type        = string
   sensitive   = true
 }

--- a/modules/argo_ci_config/variables.tf
+++ b/modules/argo_ci_config/variables.tf
@@ -1,5 +1,5 @@
-variable "argocd_namespace" {
-  description = "Namespace where ArgoCD is deployed"
+variable "argoci_namespace" {
+  description = "Namespace where ArgoCI is deployed"
   type        = string
 }
 

--- a/modules/argo_ci_config/variables.tf
+++ b/modules/argo_ci_config/variables.tf
@@ -1,0 +1,28 @@
+variable "argocd_namespace" {
+  description = "Namespace where ArgoCD is deployed"
+  type        = string
+}
+
+variable "argoci_github_workbench_operator_token" {
+  description = "GitHub token for the Workbench Operator repository"
+  type        = string
+  sensitive   = true
+}
+
+variable "argoci_github_chorus_web_ui_token" {
+  description = "GitHub token for the Chorus Web UI repository"
+  type        = string
+  sensitive   = true
+}
+
+variable "argoci_github_images_token" {
+  description = "GitHub token for the Images repository"
+  type        = string
+  sensitive   = true
+}
+
+variable "argoci_github_chorus_backend_token" {
+  description = "GitHub token for the Chorus Backend repository"
+  type        = string
+  sensitive   = true
+}

--- a/modules/argo_ci_config/variables.tf
+++ b/modules/argo_ci_config/variables.tf
@@ -8,28 +8,33 @@ variable "argoci_helm_values" {
   type        = string
 }
 
-variable "argoci_github_workbench_operator_token" {
+variable "github_workbench_operator_token" {
   description = "GitHub token for the Workbench Operator repository"
   type        = string
   sensitive   = true
 }
 
-variable "argoci_github_chorus_web_ui_token" {
+variable "github_chorus_web_ui_token" {
   description = "GitHub token for the Chorus Web UI repository"
   type        = string
   sensitive   = true
 }
 
-variable "argoci_github_images_token" {
+variable "github_images_token" {
   description = "GitHub token for the Images repository"
   type        = string
   sensitive   = true
 }
 
-variable "argoci_github_chorus_backend_token" {
+variable "github_chorus_backend_token" {
   description = "GitHub token for the Chorus Backend repository"
   type        = string
   sensitive   = true
+}
+
+variable "github_username" {
+  description = "GitHub username for Argo Workflows to use"
+  type        = string
 }
 
 variable "registry_server" {

--- a/modules/certificate_authorities/main.tf
+++ b/modules/certificate_authorities/main.tf
@@ -27,12 +27,6 @@ resource "kubernetes_manifest" "cert_manager_crds" {
     data.http.cert_manager_crds
   ]
 }
-# TODO: check if crds install can be simplified
-# kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/vX.Y.Z/cert-manager.crds.yaml
-
-# TODO: add instructions for destroying crds
-# when=destroy
-# kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/vX.Y.Z/cert-manager.crds.yaml
 
 # Cert-Manager
 
@@ -46,6 +40,11 @@ resource "helm_release" "cert_manager" {
   wait             = true
 
   values = [var.cert_manager_helm_values]
+
+  set {
+    name  = "cert-manager.crds.enabled"
+    value = "false"
+  }
 
   depends_on = [
     kubernetes_namespace.cert_manager,

--- a/modules/certificate_authorities/main.tf
+++ b/modules/certificate_authorities/main.tf
@@ -8,7 +8,6 @@ resource "kubernetes_namespace" "cert_manager" {
 
 # Cert-Manager CRDs
 
-/*
 data "http" "cert_manager_crds" {
   url = "https://github.com/cert-manager/cert-manager/releases/download/${var.cert_manager_app_version}/cert-manager.crds.yaml"
 
@@ -28,7 +27,6 @@ resource "kubernetes_manifest" "cert_manager_crds" {
     data.http.cert_manager_crds
   ]
 }
-*/
 
 # Cert-Manager
 
@@ -45,7 +43,7 @@ resource "helm_release" "cert_manager" {
 
   depends_on = [
     kubernetes_namespace.cert_manager,
-    #kubernetes_manifest.cert_manager_crds
+    kubernetes_manifest.cert_manager_crds
   ]
 }
 

--- a/modules/certificate_authorities/main.tf
+++ b/modules/certificate_authorities/main.tf
@@ -27,6 +27,12 @@ resource "kubernetes_manifest" "cert_manager_crds" {
     data.http.cert_manager_crds
   ]
 }
+# TODO: check if crds install can be simplified
+# kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/vX.Y.Z/cert-manager.crds.yaml
+
+# TODO: add instructions for destroying crds
+# when=destroy
+# kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/vX.Y.Z/cert-manager.crds.yaml
 
 # Cert-Manager
 

--- a/modules/certificate_authorities/main.tf
+++ b/modules/certificate_authorities/main.tf
@@ -45,7 +45,7 @@ resource "helm_release" "cert_manager" {
 
   depends_on = [
     kubernetes_namespace.cert_manager,
-    kubernetes_manifest.cert_manager_crds
+    #kubernetes_manifest.cert_manager_crds
   ]
 }
 

--- a/modules/certificate_authorities/main.tf
+++ b/modules/certificate_authorities/main.tf
@@ -8,6 +8,7 @@ resource "kubernetes_namespace" "cert_manager" {
 
 # Cert-Manager CRDs
 
+/*
 data "http" "cert_manager_crds" {
   url = "https://github.com/cert-manager/cert-manager/releases/download/${var.cert_manager_app_version}/cert-manager.crds.yaml"
 
@@ -27,6 +28,7 @@ resource "kubernetes_manifest" "cert_manager_crds" {
     data.http.cert_manager_crds
   ]
 }
+*/
 
 # Cert-Manager
 
@@ -38,7 +40,6 @@ resource "helm_release" "cert_manager" {
   namespace        = var.cert_manager_namespace
   create_namespace = false
   wait             = true
-  skip_crds        = true
 
   values = [var.cert_manager_helm_values]
 

--- a/modules/certificate_authorities/main.tf
+++ b/modules/certificate_authorities/main.tf
@@ -60,9 +60,11 @@ resource "null_resource" "wait_for_cert_manager_webhook" {
       set -e
       export KUBECONFIG
       kubectl config use-context ${var.kubeconfig_context}
-      for i in {1..30}; do
+      i=0
+      while [ $i -lt 30 ]; do
         kubectl -n ${var.cert_manager_namespace} get pod -l app.kubernetes.io/name=webhook -o jsonpath='{.items[0].status.containerStatuses[0].ready}' 2>/dev/null | grep -q true && exit 0
         sleep 5
+        i=$((i+1))
       done
       echo "Timeout waiting for cert-manager webhook" >&2
       exit 1

--- a/modules/harbor/main.tf
+++ b/modules/harbor/main.tf
@@ -36,7 +36,7 @@ locals {
   "oidc_client_secret": "${var.oidc_client_secret}",
   "oidc_groups_claim": "groups",
   "oidc_admin_group": "${var.oidc_admin_group}",
-  "oidc_scope": "openid,profile,offline_access,email",
+  "oidc_scope": "openid,profile,offline_access,email,groups",
   "oidc_verify_cert": "false",
   "oidc_auto_onboard": "true",
   "oidc_user_claim": "name"

--- a/modules/harbor_config/main.tf
+++ b/modules/harbor_config/main.tf
@@ -674,6 +674,99 @@ resource "harbor_robot_account" "argoci" {
   depends_on = [harbor_project.projects]
 }
 
+# ArgoCI robot account
+
+resource "random_password" "renovate_robot_password" {
+  length      = 12
+  special     = false
+  min_upper   = 1
+  min_lower   = 1
+  min_numeric = 1
+}
+
+resource "harbor_robot_account" "renovate" {
+  name        = var.renovate_robot_username
+  description = "Renovate robot account"
+  level       = "system"
+  secret      = random_password.renovate_robot_password.result
+  permissions {
+    access {
+      action = "list"
+      resource = "project"
+    }
+    access {
+      action = "list"
+      resource = "registry"
+    }
+    access {
+      action = "read"
+      resource = "registry"
+    }
+    kind = "system"
+    namespace = "/"
+  }
+  permissions {
+    access {
+      action = "list"
+      resource = "label"
+    }
+    access {
+      action = "read"
+      resource = "label"
+    }
+    access {
+      action = "list"
+      resource = "repository"
+    }
+    access {
+      action = "pull"
+      resource = "repository"
+    }
+    access {
+      action = "read"
+      resource = "repository"
+    }
+    access {
+      action = "list"
+      resource = "tag"
+    }
+    kind = "project"
+    namespace = "charts"
+  }
+  permissions {
+    access {
+      action = "list"
+      resource = "label"
+    }
+    access {
+      action = "read"
+      resource = "label"
+    }
+    access {
+      action = "list"
+      resource = "repository"
+    }
+    access {
+      action = "pull"
+      resource = "repository"
+    }
+    access {
+      action = "read"
+      resource = "repository"
+    }
+    access {
+      action = "list"
+      resource = "tag"
+    }
+    kind = "project"
+    namespace = "docker_proxy"
+  }
+  depends_on = [
+    harbor_project.projects,
+    harbor_project.proxy_cache
+  ]
+}
+
 # Add Helm charts to Harbor registry
 
 resource "null_resource" "pull_charts" {

--- a/modules/harbor_config/main.tf
+++ b/modules/harbor_config/main.tf
@@ -32,7 +32,7 @@ resource "harbor_project" "proxy_cache" {
 # GitHub Actions robot account
 
 resource "random_password" "github_actions_robot_password" {
-  length      = 12
+  length      = 32
   special     = false
   min_upper   = 1
   min_lower   = 1
@@ -100,7 +100,7 @@ resource "harbor_robot_account" "github_actions" {
 # ArgoCD robot account
 
 resource "random_password" "argocd_robot_password" {
-  length      = 12
+  length      = 32
   special     = false
   min_upper   = 1
   min_lower   = 1
@@ -191,7 +191,7 @@ resource "harbor_robot_account" "argocd" {
 # ArgoCI robot account
 
 resource "random_password" "argoci_robot_password" {
-  length      = 12
+  length      = 32
   special     = false
   min_upper   = 1
   min_lower   = 1
@@ -677,7 +677,7 @@ resource "harbor_robot_account" "argoci" {
 # ArgoCI robot account
 
 resource "random_password" "renovate_robot_password" {
-  length      = 12
+  length      = 32
   special     = false
   min_upper   = 1
   min_lower   = 1

--- a/modules/harbor_config/main.tf
+++ b/modules/harbor_config/main.tf
@@ -589,6 +589,9 @@ resource "harbor_robot_account" "argoci" {
   depends_on = [harbor_project.projects]
 }
 
+# TODO: ADD ROBOT ACCOUNT FOR GITHUB ACTIONS TO BE ALLOWED TO PUSH CHARTS TO HARBOR
+
+
 # Registries
 
 resource "harbor_registry" "docker_hub" {

--- a/modules/harbor_config/main.tf
+++ b/modules/harbor_config/main.tf
@@ -25,8 +25,8 @@ resource "harbor_project" "projects" {
 # Proxy cache projects
 
 resource "harbor_project" "proxy_cache" {
-  name        = "docker_proxy"
-  registry_id = harbor_registry.docker_hub.registry_id
+  name                   = "docker_proxy"
+  registry_id            = harbor_registry.docker_hub.registry_id
   vulnerability_scanning = "false"
   force_destroy          = true
 }

--- a/modules/harbor_config/main.tf
+++ b/modules/harbor_config/main.tf
@@ -25,7 +25,7 @@ resource "harbor_project" "projects" {
 # Proxy cache projects
 
 resource "harbor_project" "proxy_cache" {
-  name = "docker_proxy"
+  name        = "docker_proxy"
   registry_id = harbor_registry.docker_hub.id
 }
 
@@ -46,51 +46,51 @@ resource "harbor_robot_account" "github_actions" {
   secret      = random_password.github_actions_robot_password.result
   permissions {
     access {
-      action = "create"
+      action   = "create"
       resource = "label"
     }
     access {
-      action = "list"
+      action   = "list"
       resource = "label"
     }
     access {
-      action = "read"
+      action   = "read"
       resource = "label"
     }
     access {
-      action = "update"
+      action   = "update"
       resource = "label"
     }
     access {
-      action = "list"
+      action   = "list"
       resource = "repository"
     }
     access {
-      action = "pull"
+      action   = "pull"
       resource = "repository"
     }
     access {
-      action = "push"
+      action   = "push"
       resource = "repository"
     }
     access {
-      action = "read"
+      action   = "read"
       resource = "repository"
     }
     access {
-      action = "update"
+      action   = "update"
       resource = "repository"
     }
     access {
-      action = "create"
+      action   = "create"
       resource = "tag"
     }
     access {
-      action = "list"
+      action   = "list"
       resource = "tag"
     }
 
-    kind = "project"
+    kind      = "project"
     namespace = "charts"
   }
 
@@ -691,74 +691,74 @@ resource "harbor_robot_account" "renovate" {
   secret      = random_password.renovate_robot_password.result
   permissions {
     access {
-      action = "list"
+      action   = "list"
       resource = "project"
     }
     access {
-      action = "list"
+      action   = "list"
       resource = "registry"
     }
     access {
-      action = "read"
+      action   = "read"
       resource = "registry"
     }
-    kind = "system"
+    kind      = "system"
     namespace = "/"
   }
   permissions {
     access {
-      action = "list"
+      action   = "list"
       resource = "label"
     }
     access {
-      action = "read"
+      action   = "read"
       resource = "label"
     }
     access {
-      action = "list"
+      action   = "list"
       resource = "repository"
     }
     access {
-      action = "pull"
+      action   = "pull"
       resource = "repository"
     }
     access {
-      action = "read"
+      action   = "read"
       resource = "repository"
     }
     access {
-      action = "list"
+      action   = "list"
       resource = "tag"
     }
-    kind = "project"
+    kind      = "project"
     namespace = "charts"
   }
   permissions {
     access {
-      action = "list"
+      action   = "list"
       resource = "label"
     }
     access {
-      action = "read"
+      action   = "read"
       resource = "label"
     }
     access {
-      action = "list"
+      action   = "list"
       resource = "repository"
     }
     access {
-      action = "pull"
+      action   = "pull"
       resource = "repository"
     }
     access {
-      action = "read"
+      action   = "read"
       resource = "repository"
     }
     access {
-      action = "list"
+      action   = "list"
       resource = "tag"
     }
-    kind = "project"
+    kind      = "project"
     namespace = "docker_proxy"
   }
   depends_on = [

--- a/modules/harbor_config/main.tf
+++ b/modules/harbor_config/main.tf
@@ -598,6 +598,7 @@ resource "harbor_registry" "docker_hub" {
 }
 
 # Add Helm charts to Harbor registry
+# TODO: CHECK COMPATIBILITY WITH SH !!
 
 resource "null_resource" "pull_charts" {
   provisioner "local-exec" {
@@ -610,7 +611,7 @@ resource "null_resource" "pull_charts" {
     mkdir -p $destination
     for version in $versions; do
       helm registry login ${var.source_helm_registry} --username=${var.source_helm_registry_username} --password=${var.source_helm_registry_password}
-      if [[ ! -f $destination/$chart-$version.tgz ]]; then
+      if [ ! -f "$destination/$chart-$version.tgz" ]; then
         helm pull oci://${var.source_helm_registry}/charts/$chart --version $version --destination $destination
       fi
     done

--- a/modules/harbor_config/main.tf
+++ b/modules/harbor_config/main.tf
@@ -598,7 +598,6 @@ resource "harbor_registry" "docker_hub" {
 }
 
 # Add Helm charts to Harbor registry
-# TODO: CHECK COMPATIBILITY WITH SH !!
 
 resource "null_resource" "pull_charts" {
   provisioner "local-exec" {

--- a/modules/harbor_config/outputs.tf
+++ b/modules/harbor_config/outputs.tf
@@ -15,3 +15,9 @@ output "argoci_robot_password" {
   description = "Password of the robot user used by ArgoCI"
   sensitive   = true
 }
+
+output "renovate_robot_password" {
+  value       = random_password.renovate_robot_password.result
+  description = "Password of the robot user used by Renovate"
+  sensitive   = true
+}

--- a/modules/harbor_config/outputs.tf
+++ b/modules/harbor_config/outputs.tf
@@ -1,3 +1,9 @@
+output "github_actions_robot_password" {
+  value       = random_password.github_actions_robot_password.result
+  description = "Password of the robot user used by GitHub Actions"
+  sensitive   = true
+}
+
 output "argocd_robot_password" {
   value       = random_password.argocd_robot_password.result
   description = "Password of the robot user used by ArgoCD"

--- a/modules/harbor_config/variables.tf
+++ b/modules/harbor_config/variables.tf
@@ -39,6 +39,11 @@ variable "argoci_robot_username" {
   type        = string
 }
 
+variable "renovate_robot_username" {
+  description = "Username of the robot to be used by Renovate"
+  type        = string
+}
+
 variable "harbor_admin_username" {
   description = "Harbor admin username"
   type        = string

--- a/modules/harbor_config/variables.tf
+++ b/modules/harbor_config/variables.tf
@@ -24,6 +24,11 @@ variable "source_helm_registry_password" {
   sensitive   = true
 }
 
+variable "github_actions_robot_username" {
+  description = "Username of the robot to be used by GitHub Actions"
+  type        = string
+}
+
 variable "argocd_robot_username" {
   description = "Username of the robot to be used by ArgoCD"
   type        = string

--- a/modules/ingress_nginx/main.tf
+++ b/modules/ingress_nginx/main.tf
@@ -30,13 +30,15 @@ resource "null_resource" "wait_for_lb_ip" {
     set -e
     export KUBECONFIG
     kubectl config use-context ${var.kubeconfig_context}
-    for i in {1..30}; do
+    i=0
+    while [ $i -lt 30 ]; do
       IP=$(kubectl get svc ${var.cluster_name}-${var.chart_name}-controller -n ${var.namespace} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-      if [ ! -z $IP ]; then
+      if [ -n "$IP" ]; then
         exit 0
       fi
       echo "Waiting for LoadBalancer IP..."
       sleep 10
+      i=$((i+1))
     done
     echo "Timed out waiting for LoadBalancer IP" >&2
     exit 1

--- a/modules/keycloak_config/main.tf
+++ b/modules/keycloak_config/main.tf
@@ -39,10 +39,10 @@ resource "keycloak_openid_client_scope" "groups_client_scope" {
 # Group membership mapper
 
 resource "keycloak_openid_group_membership_protocol_mapper" "group_membership_mapper" {
-  realm_id  = keycloak_realm.infra.id
+  realm_id        = keycloak_realm.infra.id
   client_scope_id = keycloak_openid_client_scope.groups_client_scope.id
-  name      = "groups"
+  name            = "groups"
 
   claim_name = "groups"
-  full_path = false
+  full_path  = false
 }

--- a/modules/keycloak_config/main.tf
+++ b/modules/keycloak_config/main.tf
@@ -28,9 +28,21 @@ resource "keycloak_realm" "infra" {
 }
 
 # Client scope
-resource "keycloak_openid_client_scope" "openid_client_scope" {
+
+resource "keycloak_openid_client_scope" "groups_client_scope" {
   realm_id               = keycloak_realm.infra.id
   name                   = "groups"
   description            = "When requested, this scope will map a user's group memberships to a claim"
   include_in_token_scope = true
+}
+
+# Group membership mapper
+
+resource "keycloak_openid_group_membership_protocol_mapper" "group_membership_mapper" {
+  realm_id  = keycloak_realm.infra.id
+  client_scope_id = keycloak_openid_client_scope.groups_client_scope.id
+  name      = "groups"
+
+  claim_name = "groups"
+  full_path = false
 }

--- a/modules/oauth2_proxy/main.tf
+++ b/modules/oauth2_proxy/main.tf
@@ -11,9 +11,9 @@ locals {
   prometheus_url                                 = "https://${local.prometheus_oauth2_proxy_values_parsed.oauth2-proxy.ingress.hosts.0}"
   prometheus_existing_oidc_secret                = local.prometheus_oauth2_proxy_values_parsed.oauth2-proxy.config.existingSecret
 
-  valkey_values_parsed                       = yamldecode(var.valkey_values)
-  valkey_existing_session_storage_secret     = local.valkey_values_parsed.valkey.auth.existingSecret
-  valkey_existing_session_storage_secret_key = local.valkey_values_parsed.valkey.auth.existingSecretPasswordKey
+  oauth2_proxy_cache_values_parsed                       = yamldecode(var.oauth2_proxy_cache_values)
+  oauth2_proxy_cache_existing_session_storage_secret     = local.oauth2_proxy_cache_values_parsed.valkey.auth.existingSecret
+  oauth2_proxy_cache_existing_session_storage_secret_key = local.oauth2_proxy_cache_values_parsed.valkey.auth.existingSecretPasswordKey
 }
 
 resource "random_password" "prometheus_cookie_secret" {
@@ -89,13 +89,13 @@ resource "kubernetes_secret" "alertmanager_session_storage_secret" {
 
 # Valkey session storage secret
 
-resource "kubernetes_secret" "valkey_oauth2_proxy_secret" {
+resource "kubernetes_secret" "oauth2_proxy_cache_secret" {
   metadata {
-    name      = local.valkey_existing_session_storage_secret
-    namespace = var.valkey_namespace
+    name      = local.oauth2_proxy_cache_existing_session_storage_secret
+    namespace = var.oauth2_proxy_cache_namespace
   }
 
   data = {
-    "${local.valkey_existing_session_storage_secret_key}" = random_password.session_storage_secret.result
+    "${local.oauth2_proxy_cache_existing_session_storage_secret_key}" = random_password.session_storage_secret.result
   }
 }

--- a/modules/oauth2_proxy/variables.tf
+++ b/modules/oauth2_proxy/variables.tf
@@ -8,8 +8,8 @@ variable "prometheus_oauth2_proxy_values" {
   type        = string
 }
 
-variable "valkey_values" {
-  description = "Valkey Helm chart values"
+variable "oauth2_proxy_cache_values" {
+  description = "OAuth2 Proxy cache Helm chart values (e.g. Valkey)"
   type        = string
 }
 
@@ -23,8 +23,8 @@ variable "prometheus_oauth2_proxy_namespace" {
   type        = string
 }
 
-variable "valkey_namespace" {
-  description = "Namespace to deploy Valkey Helm chart into"
+variable "oauth2_proxy_cache_namespace" {
+  description = "Namespace to deploy the OAuth2 Proxy cache Helm chart into (e.g. Valkey)"
   type        = string
 }
 

--- a/scripts/nuke.sh
+++ b/scripts/nuke.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 nuke() {
-    cluster_name=chorus-build-t
-
     # ARGOCD
     kubie ns argocd
     helm uninstall $cluster_name-argo-cd $cluster_name-argo-cd-cache
@@ -69,9 +67,25 @@ nuke() {
 
 kubie ctx chorus-build-test 2> /dev/null
 
-echo "You are about to nuke the $(tput bold) $(kubectl config current-context) $(tput sgr0) cluster"
-read -p "Do you want to proceed? [y/N] " yn
-case $yn in
-    [yY]* ) nuke;;
-    * ) echo "Canceling."; exit 0;;
-esac
+current_context=$(kubectl config current-context)
+cat << EOF
+########################################################################
+#  _____                                     ______                    #
+# |  __ \                                   |___  /                    #
+# | |  | |  __ _  _ __    __ _   ___  _ __     / /  ___   _ __    ___  #
+# | |  | | / _  ||  _ \  / _  | / _ \|  __|   / /  / _ \ |  _ \  / _ \\ #
+# | |__| || (_| || | | || (_| ||  __/| |     / /__| (_) || | | ||  __/ #
+# |_____/  \__,_||_| |_| \__, | \___||_|    /_____|\___/ |_| |_| \___| #
+#                         __/ |                                        #
+#                        |___/                                         #
+########################################################################
+EOF
+
+echo -e "\nYou are about to destroy the $(tput bold) $current_context $(tput sgr0) cluster\n"
+read -p "Please type the cluster name to confirm: " cluster_name
+if [[ "$cluster_name" == "$current_context" ]]; then
+    nuke
+else
+    echo "Canceling"
+    exit 0
+fi

--- a/scripts/nuke.sh
+++ b/scripts/nuke.sh
@@ -1,62 +1,77 @@
 #!/bin/bash
 
-cluster_name=chorus-build-t
+nuke() {
+    cluster_name=chorus-build-t
 
-# ARGOCD
-kubie ns argocd
-helm uninstall $cluster_name-argo-cd $cluster_name-argo-cd-cache
-kubectl patch appprojects.argoproj.io $cluster_name --type=merge -p '{"metadata":{"finalizers":null}}'
-kubectl delete appprojects.argoproj.io $cluster_name
-kubectl delete ns argocd
-kubectl delete $(kubectl get crds -oname | grep argoproj.io)
+    # ARGOCD
+    kubie ns argocd
+    helm uninstall $cluster_name-argo-cd $cluster_name-argo-cd-cache
+    kubectl patch appprojects.argoproj.io $cluster_name --type=merge -p '{"metadata":{"finalizers":null}}'
+    kubectl delete appprojects.argoproj.io $cluster_name
+    kubectl delete ns argocd
+    kubectl delete $(kubectl get crds -oname | grep argoproj.io)
 
-# ARGO-EVENTS
-kubie ns argo-events
-kubectl delete $(kubectl get deployment -oname)
-kubectl delete ns argo-events
+    # ARGO-EVENTS
+    kubie ns argo-events
+    kubectl delete $(kubectl get deployment -oname)
+    kubectl delete ns argo-events
 
-# PROMETHEUS
-kubie ns prometheus
-kubectl delete $(kubectl get deployment -oname)
-challenges=$(kubectl get challenges.acme.cert-manager.io -oname)
-for challenge in $challenges; do
-    kubectl patch $challenge --type=merge -p '{"metadata":{"finalizers":null}}'
-    kubectl delete $challenge
-done
-kubectl delete ns prometheus
-kubectl delete $(kubectl get crds -oname | grep coreos.com)
-kubectl delete $(kubectl get crds -oname | grep aquasecurity.github.io)
+    # PROMETHEUS
+    kubie ns prometheus
+    kubectl delete $(kubectl get deployment -oname)
+    challenges=$(kubectl get challenges.acme.cert-manager.io -oname)
+    for challenge in $challenges; do
+        kubectl patch $challenge --type=merge -p '{"metadata":{"finalizers":null}}'
+        kubectl delete $challenge
+    done
+    kubectl delete ns prometheus
+    kubectl delete $(kubectl get crds -oname | grep coreos.com)
+    kubectl delete $(kubectl get crds -oname | grep aquasecurity.github.io)
 
-# ARGO-WORKFLOW
-kubie ns kube-system
-kubectl patch $(kubectl get challenges.acme.cert-manager.io -oname) --type=merge -p '{"metadata":{"finalizers":null}}'
-kubectl delete $(kubectl get challenges.acme.cert-manager.io -oname)
-kubectl delete $(kubectl get deployments.apps -oname | grep "argo-workflows")
-kubectl delete secret argo-workflows-oidc argo-workflows-tls
-kubectl delete ns argo
+    # ARGO-WORKFLOW
+    kubie ns kube-system
+    kubectl patch $(kubectl get challenges.acme.cert-manager.io -oname) --type=merge -p '{"metadata":{"finalizers":null}}'
+    kubectl delete $(kubectl get challenges.acme.cert-manager.io -oname)
+    kubectl delete $(kubectl get deployments.apps -oname | grep "argo-workflows")
+    kubectl delete secret argo-workflows-oidc argo-workflows-tls
+    kubectl delete ns argo
 
-# TRIVY
-kubie ns trivy-system
-kubectl delete deployment $cluster_name-trivy-operator
-kubectl delete ns trivy-system
+    # TRIVY
+    kubie ns trivy-system
+    kubectl delete deployment $cluster_name-trivy-operator
+    kubectl delete ns trivy-system
 
-# HARBOR
-kubie ns harbor
-helm uninstall $cluster_name-harbor $cluster_name-harbor-cache $cluster_name-harbor-db
-kubectl delete ns harbor
+    # HARBOR
+    kubie ns harbor
+    helm uninstall $cluster_name-harbor $cluster_name-harbor-cache $cluster_name-harbor-db
+    kubectl delete ns harbor
 
-# KEYCLOAK
-kubie ns keycloak
-helm uninstall $cluster_name-keycloak $cluster_name-keycloak-db
-kubectl delete ns keycloak
+    # KEYCLOAK
+    kubie ns keycloak
+    helm uninstall $cluster_name-keycloak $cluster_name-keycloak-db
+    kubectl delete ns keycloak
 
-# CERT-MANAGER
-kubie ns cert-manager
-helm uninstall $cluster_name-cert-manager $cluster_name-self-signed-issuer
-kubectl delete ns cert-manager
-kubectl delete $(kubectl get crds -oname | grep cert-manager.io)
+    # CERT-MANAGER
+    kubie ns cert-manager
+    helm uninstall $cluster_name-cert-manager $cluster_name-self-signed-issuer
+    kubectl delete ns cert-manager
+    kubectl delete $(kubectl get crds -oname | grep cert-manager.io)
 
-# NGINX
-kubie ns ingress-nginx
-helm uninstall $cluster_name-ingress-nginx
-kubectl delete ns ingress-nginx
+    # NGINX
+    kubie ns ingress-nginx
+    helm uninstall $cluster_name-ingress-nginx
+    kubectl delete ns ingress-nginx
+
+    kubie ns default
+}
+
+# --- Script Execution Start ---
+
+kubie ctx chorus-build-test 2> /dev/null
+
+echo "You are about to nuke the $(tput bold) $(kubectl config current-context) $(tput sgr0) cluster"
+read -p "Do you want to proceed? [y/N] " yn
+case $yn in
+    [yY]* ) nuke;;
+    * ) echo "Canceling."; exit 0;;
+esac

--- a/stage_00/backend.tf
+++ b/stage_00/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  cloud {
+    organization = "CHORUS-TRE"
+    workspaces {
+      project = "chorus-install"
+      tags    = ["stage_00"]
+    }
+  }
+}

--- a/stage_00/main.tf
+++ b/stage_00/main.tf
@@ -2,6 +2,9 @@ locals {
   cert_manager_chart_version = data.external.cert_manager_config.result.version
 }
 
+# TODO: do a check on var.helm_values_pat
+# to see if we are checking a public or private repo
+# and act accordingly
 resource "null_resource" "fetch_helm_charts_values" {
   provisioner "local-exec" {
     quiet   = true
@@ -10,7 +13,7 @@ resource "null_resource" "fetch_helm_charts_values" {
         mkdir -p ${var.helm_values_path}/${var.helm_values_repo}
         cd ${var.helm_values_path}/${var.helm_values_repo}
         git init -q
-        git remote add origin https://github.com/${var.github_orga}/${var.helm_values_repo}.git
+        git remote add origin https://${var.github_orga}:${var.helm_values_pat}@github.com/${var.github_orga}/${var.helm_values_repo}.git
         git fetch -q origin ${var.chorus_release}
         git sparse-checkout set ${var.cluster_name}
         git checkout -q ${var.chorus_release}

--- a/stage_00/main.tf
+++ b/stage_00/main.tf
@@ -11,7 +11,7 @@ resource "null_resource" "fetch_helm_charts_values" {
         cd ${var.helm_values_path}/${var.helm_values_repo}
         git init -q
         pat=${coalesce(var.helm_values_pat, "public")}
-        if [[  "$pat" == "public" ]]; then
+        if [ "$pat" = "public" ]; then
           git remote add origin https://github.com/${var.github_orga}/${var.helm_values_repo}.git
         else
           git remote add origin https://${var.github_orga}:$pat@github.com/${var.github_orga}/${var.helm_values_repo}.git

--- a/stage_00/main.tf
+++ b/stage_00/main.tf
@@ -39,6 +39,7 @@ resource "null_resource" "fetch_cert_manager_app_version" {
     command = <<EOT
       set -e
       mkdir -p ${path.module}/tmp
+      helm registry login ${var.helm_registry} -u ${var.helm_registry_username} -p ${var.helm_registry_password}
       helm pull "oci://${var.helm_registry}/charts/${var.cert_manager_chart_name}" --version ${local.cert_manager_chart_version} --destination ${path.module}/tmp
       tar -xzf ${path.module}/tmp/cert-manager-*.tgz -C ${path.module}/tmp
       touch ${var.helm_values_path}/${var.cluster_name}/${var.cert_manager_chart_name}/app_version

--- a/stage_00/variables.tf
+++ b/stage_00/variables.tf
@@ -10,6 +10,13 @@ variable "helm_values_repo" {
   default     = "environment-template"
 }
 
+variable "helm_values_pat" {
+  description = "Fine-grained personal access token (PAT) to access the Helm chart values repository (e.g. CHORUS-TRE/environment-template)"
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
 variable "chorus_release" {
   description = "CHORUS-TRE release to use"
   type        = string

--- a/stage_00/variables.tf
+++ b/stage_00/variables.tf
@@ -44,3 +44,14 @@ variable "helm_registry" {
   description = "CHORUS Helm chart registry"
   type        = string
 }
+
+variable "helm_registry_username" {
+  description = "Username to connect to the CHORUS Helm chart registry"
+  type        = string
+}
+
+variable "helm_registry_password" {
+  description = "Password to connect to the CHORUS Helm chart registry"
+  type        = string
+  sensitive   = true
+}

--- a/stage_01/backend.tf
+++ b/stage_01/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  cloud {
+    organization = "CHORUS-TRE"
+    workspaces {
+      project = "chorus-install"
+      tags    = ["stage_01"]
+    }
+  }
+}

--- a/stage_02/backend.tf
+++ b/stage_02/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  cloud {
+    organization = "CHORUS-TRE"
+    workspaces {
+      project = "chorus-install"
+      tags    = ["stage_02"]
+    }
+  }
+}

--- a/stage_02/main.tf
+++ b/stage_02/main.tf
@@ -486,12 +486,14 @@ module "argoci_config" {
 
 locals {
   output = {
-    harbor_admin_username        = var.harbor_admin_username
-    harbor_admin_password        = local.harbor_admin_password
-    harbor_url                   = local.harbor_url
-    harbor_admin_url             = join("/", [local.harbor_url, "account", "sign-in"])
-    harbor_argoci_robot_password = module.harbor_config.argoci_robot_password
-    harbor_argocd_robot_password = module.harbor_config.argocd_robot_password
+    harbor_admin_username = var.harbor_admin_username
+    harbor_admin_password = local.harbor_admin_password
+    harbor_url            = local.harbor_url
+    harbor_admin_url      = join("/", [local.harbor_url, "account", "sign-in"])
+
+    harbor_argoci_robot_password   = module.harbor_config.argoci_robot_password
+    harbor_argocd_robot_password   = module.harbor_config.argocd_robot_password
+    harbor_renovate_robot_password = module.harbor_config.renovate_robot_password
 
     keycloak_admin_username = var.keycloak_admin_username
     keycloak_admin_password = local.keycloak_admin_password

--- a/stage_02/main.tf
+++ b/stage_02/main.tf
@@ -55,8 +55,8 @@ locals {
   prometheus_oauth2_proxy_values_parsed = yamldecode(local.prometheus_oauth2_proxy_values)
   prometheus_url                        = "https://${local.prometheus_oauth2_proxy_values_parsed.oauth2-proxy.ingress.hosts.0}"
 
-  valkey_oauth2_proxy_namespace = jsondecode(file("${var.helm_values_path}/${var.cluster_name}/${var.valkey_oauth2_proxy_chart_name}/config.json")).namespace
-  valkey_oauth2_proxy_values    = file("${var.helm_values_path}/${var.cluster_name}/${var.valkey_oauth2_proxy_chart_name}/values.yaml")
+  oauth2_proxy_cache_namespace = jsondecode(file("${var.helm_values_path}/${var.cluster_name}/${var.oauth2_proxy_cache_chart_name}/config.json")).namespace
+  oauth2_proxy_cache_values    = file("${var.helm_values_path}/${var.cluster_name}/${var.oauth2_proxy_cache_chart_name}/values.yaml")
 }
 
 # Providers
@@ -233,10 +233,10 @@ module "oauth2_proxy" {
 
   alertmanager_oauth2_proxy_values    = local.alertmanager_oauth2_proxy_values
   prometheus_oauth2_proxy_values      = local.prometheus_oauth2_proxy_values
-  valkey_values                       = local.valkey_oauth2_proxy_values
+  oauth2_proxy_cache_values           = local.oauth2_proxy_cache_values
   alertmanager_oauth2_proxy_namespace = local.alertmanager_oauth2_proxy_namespace
   prometheus_oauth2_proxy_namespace   = local.prometheus_oauth2_proxy_namespace
-  valkey_namespace                    = local.valkey_oauth2_proxy_namespace
+  oauth2_proxy_cache_namespace        = local.oauth2_proxy_cache_namespace
   prometheus_keycloak_client_id       = var.prometheus_keycloak_client_id
   prometheus_keycloak_client_secret   = random_password.prometheus_keycloak_client_secret.result
   alertmanager_keycloak_client_id     = var.alertmanager_keycloak_client_id

--- a/stage_02/main.tf
+++ b/stage_02/main.tf
@@ -417,13 +417,15 @@ resource "null_resource" "wait_for_argocd" {
     quiet   = true
     command = <<EOT
       set -e
-      for i in {1..30}; do
-        if [ $(curl -skf -o /dev/null -w "%%{http_code}" ${module.argo_cd.argocd_url}/healthz) -eq 200 ]; then
+      i=0
+      while [ $i -lt 30 ]; do
+        if [ "$(curl -skf -o /dev/null -w "%%{http_code}" ${module.argo_cd.argocd_url}/healthz)" -eq 200 ]; then
           exit 0
         else
           echo "Waiting for ArgoCD... ($i)"
           sleep 10
         fi
+        i=$((i+1))
       done
       echo "Timed out waiting for ArgoCD" >&2
       exit 1

--- a/stage_02/main.tf
+++ b/stage_02/main.tf
@@ -7,6 +7,7 @@ locals {
   argocd_chart_version       = jsondecode(file("${var.helm_values_path}/${var.cluster_name}/${var.argocd_chart_name}/config.json")).version
   argocd_cache_chart_version = jsondecode(file("${var.helm_values_path}/${var.cluster_name}/${var.argocd_chart_name}-cache/config.json")).version
   argocd_namespace           = jsondecode(file("${var.helm_values_path}/${var.cluster_name}/${var.argocd_chart_name}/config.json")).namespace
+  argoci_namespace           = jsondecode(file("${var.helm_values_path}/${var.cluster_name}/${var.argoci_chart_name}/config.json")).namespace
 
   harbor_values                             = file("${var.helm_values_path}/${var.cluster_name}/${var.harbor_chart_name}/values.yaml")
   harbor_values_parsed                      = yamldecode(local.harbor_values)
@@ -465,7 +466,7 @@ module "argocd_config" {
 module "argoci_config" {
   source = "../modules/argo_ci_config"
 
-  argocd_namespace = local.argocd_namespace
+  argoci_namespace = local.argoci_namespace
 
   argoci_github_chorus_web_ui_token      = var.argoci_github_chorus_web_ui_token
   argoci_github_images_token             = var.argoci_github_images_token

--- a/stage_02/main.tf
+++ b/stage_02/main.tf
@@ -308,6 +308,7 @@ module "keycloak_argo_workflows_client_config" {
   admin_url           = local.argo_workflows_url
   web_origins         = [local.argo_workflows_url]
   valid_redirect_uris = [local.argo_workflows_redirect_uri]
+  client_group        = var.argo_workflows_keycloak_oidc_admin_group
 }
 
 module "keycloak_grafana_client_config" {
@@ -379,9 +380,9 @@ module "harbor_config" {
   harbor_helm_values    = file("${var.helm_values_path}/${var.cluster_name}/${var.harbor_chart_name}/values.yaml")
 
   github_actions_robot_username = var.github_actions_harbor_robot_username
-  argocd_robot_username = var.argocd_harbor_robot_username
-  argoci_robot_username = var.argoci_harbor_robot_username
-  renovate_robot_username = var.renovate_harbor_robot_username
+  argocd_robot_username         = var.argocd_harbor_robot_username
+  argoci_robot_username         = var.argoci_harbor_robot_username
+  renovate_robot_username       = var.renovate_harbor_robot_username
 }
 
 module "argo_cd" {

--- a/stage_02/main.tf
+++ b/stage_02/main.tf
@@ -467,12 +467,17 @@ module "argocd_config" {
 module "argoci_config" {
   source = "../modules/argo_ci_config"
 
-  argoci_namespace = local.argoci_namespace
+  argoci_namespace   = local.argoci_namespace
+  argoci_helm_values = file("${var.helm_values_path}/${var.cluster_name}/${var.argoci_chart_name}/values.yaml")
 
   argoci_github_chorus_web_ui_token      = var.argoci_github_chorus_web_ui_token
   argoci_github_images_token             = var.argoci_github_images_token
   argoci_github_chorus_backend_token     = var.argoci_github_chorus_backend_token
   argoci_github_workbench_operator_token = var.argoci_github_workbench_operator_token
+
+  registry_server   = local.harbor_url
+  registry_username = var.argoci_harbor_robot_username
+  registry_password = module.harbor_config.argoci_robot_password
 }
 
 locals {

--- a/stage_02/main.tf
+++ b/stage_02/main.tf
@@ -377,6 +377,7 @@ module "harbor_config" {
   harbor_admin_password = local.harbor_admin_password
   harbor_helm_values    = file("${var.helm_values_path}/${var.cluster_name}/${var.harbor_chart_name}/values.yaml")
 
+  github_actions_robot_username = var.github_actions_harbor_robot_username
   argocd_robot_username = var.argocd_harbor_robot_username
   argoci_robot_username = var.argoci_harbor_robot_username
 }

--- a/stage_02/main.tf
+++ b/stage_02/main.tf
@@ -380,6 +380,7 @@ module "harbor_config" {
   github_actions_robot_username = var.github_actions_harbor_robot_username
   argocd_robot_username = var.argocd_harbor_robot_username
   argoci_robot_username = var.argoci_harbor_robot_username
+  renovate_robot_username = var.renovate_harbor_robot_username
 }
 
 module "argo_cd" {

--- a/stage_02/main.tf
+++ b/stage_02/main.tf
@@ -470,10 +470,12 @@ module "argoci_config" {
   argoci_namespace   = local.argoci_namespace
   argoci_helm_values = file("${var.helm_values_path}/${var.cluster_name}/${var.argoci_chart_name}/values.yaml")
 
-  argoci_github_chorus_web_ui_token      = var.argoci_github_chorus_web_ui_token
-  argoci_github_images_token             = var.argoci_github_images_token
-  argoci_github_chorus_backend_token     = var.argoci_github_chorus_backend_token
-  argoci_github_workbench_operator_token = var.argoci_github_workbench_operator_token
+  github_chorus_web_ui_token      = var.github_chorus_web_ui_token
+  github_images_token             = var.github_images_token
+  github_chorus_backend_token     = var.github_chorus_backend_token
+  github_workbench_operator_token = var.github_workbench_operator_token
+
+  github_username = var.github_username
 
   registry_server   = local.harbor_url
   registry_username = var.argoci_harbor_robot_username

--- a/stage_02/variables.tf
+++ b/stage_02/variables.tf
@@ -52,6 +52,7 @@ variable "helm_values_pat" {
   description = "Fine-grained personal access token (PAT) to access the Helm chart values repository (e.g. CHORUS-TRE/environment-template)"
   type        = string
   sensitive   = true
+  default     = null
 }
 
 variable "argocd_chart_name" {
@@ -256,4 +257,28 @@ variable "grafana_admin_username" {
   description = "Grafana admin username"
   type        = string
   default     = "admin"
+}
+
+variable "argoci_github_workbench_operator_token" {
+  description = "GitHub token for the Workbench Operator repository"
+  type        = string
+  sensitive   = true
+}
+
+variable "argoci_github_chorus_web_ui_token" {
+  description = "GitHub token for the Chorus Web UI repository"
+  type        = string
+  sensitive   = true
+}
+
+variable "argoci_github_images_token" {
+  description = "GitHub token for the Images repository"
+  type        = string
+  sensitive   = true
+}
+
+variable "argoci_github_chorus_backend_token" {
+  description = "GitHub token for the Chorus Backend repository"
+  type        = string
+  sensitive   = true
 }

--- a/stage_02/variables.tf
+++ b/stage_02/variables.tf
@@ -223,6 +223,12 @@ variable "argocd_keycloak_oidc_admin_group" {
   default     = "ArgoCDAdmins"
 }
 
+variable "argo_workflows_keycloak_oidc_admin_group" {
+  description = "Keycloak OIDC admin group assigned to Argo Workflows"
+  type        = string
+  default     = "ArgoWorkflowsAdmins"
+}
+
 variable "grafana_keycloak_oidc_admin_group" {
   description = "Keycloak OIDC admin group assigned to Grafana"
   type        = string

--- a/stage_02/variables.tf
+++ b/stage_02/variables.tf
@@ -127,6 +127,12 @@ variable "helm_values_credentials_secret" {
   default     = "argo-cd-github-environments"
 }
 
+variable "github_actions_harbor_robot_username" {
+  description = "Harbor robot username used by GitHub Actions"
+  type        = string
+  default     = "chorus-tre"
+}
+
 variable "argocd_harbor_robot_username" {
   description = "Harbor robot username used by ArgoCD"
   type        = string

--- a/stage_02/variables.tf
+++ b/stage_02/variables.tf
@@ -79,10 +79,10 @@ variable "valkey_chart_name" {
   default     = "valkey"
 }
 
-variable "valkey_oauth2_proxy_chart_name" {
-  description = "Valkey OAuth2 Proxy Helm chart name"
+variable "oauth2_proxy_cache_chart_name" {
+  description = "OAuth2 Proxy cache Helm chart name"
   type        = string
-  default     = "oauth2-proxy-valkey"
+  default     = "oauth2-proxy-cache"
 }
 
 variable "alertmanager_oauth2_proxy_chart_name" {

--- a/stage_02/variables.tf
+++ b/stage_02/variables.tf
@@ -283,25 +283,30 @@ variable "grafana_admin_username" {
   default     = "admin"
 }
 
-variable "argoci_github_workbench_operator_token" {
+variable "github_username" {
+  description = "GitHub username owner of all the tokens"
+  type        = string
+}
+
+variable "github_workbench_operator_token" {
   description = "GitHub token for the Workbench Operator repository"
   type        = string
   sensitive   = true
 }
 
-variable "argoci_github_chorus_web_ui_token" {
+variable "github_chorus_web_ui_token" {
   description = "GitHub token for the Chorus Web UI repository"
   type        = string
   sensitive   = true
 }
 
-variable "argoci_github_images_token" {
+variable "github_images_token" {
   description = "GitHub token for the Images repository"
   type        = string
   sensitive   = true
 }
 
-variable "argoci_github_chorus_backend_token" {
+variable "github_chorus_backend_token" {
   description = "GitHub token for the Chorus Backend repository"
   type        = string
   sensitive   = true

--- a/stage_02/variables.tf
+++ b/stage_02/variables.tf
@@ -139,6 +139,12 @@ variable "argocd_harbor_robot_username" {
   default     = "argo-cd"
 }
 
+variable "argoci_chart_name" {
+  description = "ArgoCI Helm chart name"
+  type        = string
+  default     = "argo-ci"
+}
+
 variable "argoci_harbor_robot_username" {
   description = "Harbor robot username used by ArgoCI"
   type        = string

--- a/stage_02/variables.tf
+++ b/stage_02/variables.tf
@@ -145,6 +145,12 @@ variable "argoci_harbor_robot_username" {
   default     = "argo-ci"
 }
 
+variable "renovate_harbor_robot_username" {
+  description = "Harbor robot username used by Renovate"
+  type        = string
+  default     = "renovate"
+}
+
 variable "keycloak_chart_name" {
   description = "Keycloak Helm chart folder name"
   type        = string


### PR DESCRIPTION
## Remote State Support

- Added backend.tf files to stage_00, stage_01, and stage_02 to enable remote Terraform state management.

## Shell Script Portability

- Removed bashisms
- Applied to scripts in modules like certificate_authorities, ingress_nginx, and harbor_config.

## Variable and Secret Handling

- Added new tokens and variables for the argoci module.
- Dropped redundant argoci_ prefixes in variable names e.g., argoci_github_chorus_backend_token → github_chorus_backend_token.

## Harbor and OIDC Improvements

- Added support for Harbor robot accounts for Renovate and GitHub Actions.
- Updated OIDC configuration to include the groups scope: "oidc_scope": "openid,profile,offline_access,email,groups"

## Cert-Manager Helm Release

- Prevented the Helm chart from installing CRDs by default.

## Documentation and Outputs

- Updated .env.example with new environment variables.
- Added Renovate robot password to output files.

## Safeguard
- Added a safeguard prompt to scripts/nuke.sh to prevent accidental destruction of resources.